### PR TITLE
remove androidx.test dependency from lib

### DIFF
--- a/connect-sdk/build.gradle
+++ b/connect-sdk/build.gradle
@@ -101,7 +101,6 @@ dependencies {
 
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.browser:browser:1.0.0'
-    implementation 'androidx.test:monitor:1.5.0'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-inline:3.4.0'
@@ -110,6 +109,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.10.1'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:monitor:1.5.0'
     androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'


### PR DESCRIPTION
androidx.test:monitor is distributed as dependency of connect-sdk. It's presence interferes with sdk users builds